### PR TITLE
[TBAU-1724] Remove unused Rails dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sealink Param Validation
 
+## Unreleased
+
+- [TBAU-1724] Remove unused Rails dependencies
+
 ## 0.4.0
 
 - [PLAT-1175] Update to Ruby 3.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Ruby gem (`sealink-param-validation`) that provides Rails controller parameter validation using dry-schema. Controllers include `SealinkParamValidation::Concern` and declare schemas per action via `schema_for`. Invalid params return 422 with error messages.
+
+## Commands
+
+```bash
+bundle install          # Install dependencies
+bundle exec rspec       # Run all tests
+bundle exec rspec spec/helper_spec.rb  # Run a single spec file
+```
+
+## Architecture
+
+- **`lib/sealink_param_validation/concern.rb`** — ActiveSupport::Concern included in controllers. `schema_for(action, schema)` registers a dry-schema per action and adds a `before_action` that validates params. Two validation paths: `ensure_schema` (renders 422 JSON) and `ensure_schema!` (raises `InvalidInputError`).
+- **`lib/sealink_param_validation/helper.rb`** — Formats dry-schema validation errors into strings. `generate_error_message` returns full error paths; `generate_humanized_error_message` returns humanized field names with `to_sentence`.
+- **`lib/sealink_param_validation/error.rb`** — `InvalidInputError` exception class.
+
+## Key Dependencies
+
+- `rails` (ActiveSupport::Concern, ActionController)
+- `dry-schema` (>= 1.0.0) for param validation schemas
+
+## Testing
+
+Tests use `rspec-rails` with a minimal Rails application defined in `spec/spec_helper.rb`. The validation spec creates a `DummyController` with routes to test the concern end-to-end.
+
+## Release Process
+
+1. Update version in `lib/sealink_param_validation/version.rb` and `CHANGELOG.md`
+2. Create a git tag in format `v0.1.0`
+3. Push — GitHub Actions handles the build/publish

--- a/sealink_param_validation.gemspec
+++ b/sealink_param_validation.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'rails'
+  spec.add_dependency 'activesupport'
+  spec.add_dependency 'actionpack'
   spec.add_dependency 'dry-schema', '>= 1.0.0'
 
   spec.add_development_dependency 'bundler'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ENV['RAILS_ENV'] ||= 'test'
-require 'rails'
+require 'logger'
 require 'action_controller/railtie'
 require 'dry-schema'
 require 'rspec/rails'


### PR DESCRIPTION
### WHY
We want to remove unused Rails dependencies and only include what we are using.

- activesupport — for ActiveSupport::Concern, class_attribute, .present?, .humanize, .to_sentence
- actionpack — for ActionController::Base, before_action, render, params
- railties — pulled in transitively by the existing rspec-rails

### TEST
Pipeline passed